### PR TITLE
fix: resolve blocking issues for Modules 3/4/5 on GPU (A100)

### DIFF
--- a/code/3-agent-evaluation/evaluation_framework.answers.py
+++ b/code/3-agent-evaluation/evaluation_framework.answers.py
@@ -474,6 +474,7 @@ def evaluate_report_quality(
         return {
             "structure": EvaluationResult(score=0.0, explanation="Parse failed", metric_name="structure"),
             "content": EvaluationResult(score=0.0, explanation="Parse failed", metric_name="content"),
+            "coverage": EvaluationResult(score=0.0, explanation="Parse failed", metric_name="coverage"),
             "accuracy": EvaluationResult(score=0.0, explanation="Parse failed", metric_name="accuracy"),
             "writing": EvaluationResult(score=0.0, explanation="Parse failed", metric_name="writing"),
         }

--- a/code/3-agent-evaluation/evaluation_framework.py
+++ b/code/3-agent-evaluation/evaluation_framework.py
@@ -469,6 +469,7 @@ def evaluate_report_quality(
         return {
             "structure": EvaluationResult(score=0.0, explanation="Parse failed", metric_name="structure"),
             "content": EvaluationResult(score=0.0, explanation="Parse failed", metric_name="content"),
+            "coverage": EvaluationResult(score=0.0, explanation="Parse failed", metric_name="coverage"),
             "accuracy": EvaluationResult(score=0.0, explanation="Parse failed", metric_name="accuracy"),
             "writing": EvaluationResult(score=0.0, explanation="Parse failed", metric_name="writing"),
         }

--- a/postBuild.bash
+++ b/postBuild.bash
@@ -25,6 +25,20 @@ else
     echo "File already exists. No action taken."
 fi
 
+# Install Mamba/Nemotron CUDA extensions (must be built with CUDA present)
+pip install --no-build-isolation "causal-conv1d @ git+https://github.com/Dao-AILab/causal-conv1d.git@v1.5.2"
+pip install --no-build-isolation "mamba-ssm @ git+https://github.com/state-spaces/mamba.git@v2.2.5"
+
+# Patch mamba-ssm for transformers 5.x compatibility
+# (mamba-ssm 2.2.5 imports GreedySearchDecoderOnlyOutput which was removed in transformers 5.x)
+MAMBA_GEN=$(python3 -c "import importlib.util; spec = importlib.util.find_spec('mamba_ssm'); print(spec.submodule_search_locations[0])" 2>/dev/null)/utils/generation.py
+if [ -f "$MAMBA_GEN" ]; then
+    sed -i 's/from transformers.generation import GreedySearchDecoderOnlyOutput, SampleDecoderOnlyOutput, TextStreamer/try:\n    from transformers.generation import GreedySearchDecoderOnlyOutput, SampleDecoderOnlyOutput, TextStreamer\nexcept ImportError:\n    from transformers.generation import GenerateDecoderOnlyOutput as GreedySearchDecoderOnlyOutput, GenerateDecoderOnlyOutput as SampleDecoderOnlyOutput, TextStreamer/' "$MAMBA_GEN"
+    echo "Patched mamba-ssm for transformers 5.x compatibility"
+else
+    echo "WARNING: Could not find mamba-ssm generation.py to patch"
+fi
+
 # Install CUDA Toolkit
 # 1. Detect Architecture
 ARCH=$(uname -m)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 data-designer~=0.3.7
+deepagents>=0.3.11
 duckdb~=1.4.4
 dotenv~=0.9.9
 faiss-cpu~=1.12.0
@@ -20,6 +21,7 @@ OpenAI
 pandas~=2.3.0
 pydantic
 ragas~=0.2.0
+scikit-learn~=1.6.0
 streamlit~=1.49.1
 tavily-python~=0.7.19
 voila

--- a/variables.env
+++ b/variables.env
@@ -1,4 +1,4 @@
 SHELL=/bin/bash
-LANGSMITH_TRACING=true
+LANGSMITH_TRACING=false
 LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 LANGSMITH_PROJECT=nv-devx


### PR DESCRIPTION
Clean slate users should be good to run this for 3,4,5

- Add deepagents and scikit-learn to requirements.txt (missing deps for Modules 4/5)
- Add causal-conv1d and mamba-ssm CUDA builds to postBuild.bash (Nemotron model needs these)
- Patch mamba-ssm for transformers 5.x compatibility (GreedySearchDecoderOnlyOutput removed)
- Add missing 'coverage' key to evaluation_framework fallback dict (KeyError on LLM parse failure)
- Disable LangSmith tracing by default (no API key configured = wall of 401 errors)
