### PR TITLE
fix: replace EOL NIM embedding and reranking models

### DIFF
--- a/.devx/2-agentic-rag/agentic_rag.md
+++ b/.devx/2-agentic-rag/agentic_rag.md
@@ -55,7 +55,7 @@ Embeddings convert text into numerical vectors that capture semantic meaning. Te
 
 These chunks need to be embedded into vectors for the database. This is done with the `RETRIEVER_EMBEDDING_MODEL` defined before.
 
-Use the [NVIDIAEmbeddings](https://build.nvidia.com/nvidia/llama-3_2-nv-embedqa-1b-v2?snippet_tab=LangChain) class to define <button onclick="goToLineAndSelect('code/2-agentic-rag/rag_agent.py', 'embeddings = ');"><i class="fas fa-code"></i> embeddings</button>. The API Key has already been configured, it does not need to be specified. Set truncate to `END`.
+Use the [NVIDIAEmbeddings](https://build.nvidia.com/nvidia/nv-embedqa-e5-v5?snippet_tab=LangChain) class to define <button onclick="goToLineAndSelect('code/2-agentic-rag/rag_agent.py', 'embeddings = ');"><i class="fas fa-code"></i> embeddings</button>. The API Key has already been configured, it does not need to be specified. Set truncate to `END`.
 
 <details>
 <summary>🆘 Need some help?</summary>
@@ -95,7 +95,7 @@ LangChain allows us to easily create a basic retrieval chain from our Vector Dat
 
 ### Reranking Model
 
-NVIDIA offers a Reranker model to improve the relevance and order of retrieved documents. Use the [NVIDIARerank](https://build.nvidia.com/nvidia/llama-3_2-nv-rerankqa-1b-v2?snippet_tab=LangChain) class to define <button onclick="goToLineAndSelect('code/2-agentic-rag/rag_agent.py', 'reranker = ');"><i class="fas fa-code"></i> reranker</button>.
+NVIDIA offers a Reranker model to improve the relevance and order of retrieved documents. Use the [NVIDIARerank](https://build.nvidia.com/nvidia/llama-nemotron-rerank-1b-v2?snippet_tab=LangChain) class to define <button onclick="goToLineAndSelect('code/2-agentic-rag/rag_agent.py', 'reranker = ');"><i class="fas fa-code"></i> reranker</button>.
 
 <details>
 <summary>🆘 Need some help?</summary>

--- a/.devx/2-agentic-rag/migrate.md
+++ b/.devx/2-agentic-rag/migrate.md
@@ -218,8 +218,8 @@ So far, we've only migrated one of our three models to run locally.
 
 Recall that our agent also uses two additional models:
 
-  - [Reranker: llama-3_2-nv-rerankqa-1b-v2](https://build.nvidia.com/nvidia/llama-3_2-nv-rerankqa-1b-v2)
-  - [Embedding: llama-3_2-nv-embedqa-1b-v2](https://build.nvidia.com/nvidia/llama-3_2-nv-embedqa-1b-v2)
+  - [Reranker: llama-nemotron-rerank-1b-v2](https://build.nvidia.com/nvidia/llama-nemotron-rerank-1b-v2)
+  - [Embedding: nv-embedqa-e5-v5](https://build.nvidia.com/nvidia/nv-embedqa-e5-v5)
 
 If you have access to a second GPU, consider running these models locally as well. You can follow the same process as before: consult the official docs for each model, launch their NIM endpoints, and update your agent code to point to the new local URLs (using the `base_url` parameter).
 

--- a/code/2-agentic-rag/rag_agent.answers.py
+++ b/code/2-agentic-rag/rag_agent.answers.py
@@ -35,8 +35,8 @@ CHUNK_OVERLAP = 120
 
 # Model Configuration
 LLM_MODEL = "nvidia/nemotron-3-super-120b-a12b"
-RETRIEVER_RERANK_MODEL = "nvidia/llama-3.2-nv-rerankqa-1b-v2"
-RETRIEVER_EMBEDDING_MODEL = "nvidia/llama-3.2-nv-embedqa-1b-v2"
+RETRIEVER_RERANK_MODEL = "nvidia/llama-nemotron-rerank-1b-v2"
+RETRIEVER_EMBEDDING_MODEL = "nvidia/nv-embedqa-e5-v5"
 
 # API Keys
 TAVILY_API_KEY = os.environ.get("TAVILY_API_KEY", "")

--- a/code/2-agentic-rag/rag_agent.py
+++ b/code/2-agentic-rag/rag_agent.py
@@ -35,8 +35,8 @@ CHUNK_OVERLAP = 120
 
 # Model Configuration
 LLM_MODEL = "nvidia/nemotron-3-super-120b-a12b"
-RETRIEVER_RERANK_MODEL = "nvidia/llama-3.2-nv-rerankqa-1b-v2"
-RETRIEVER_EMBEDDING_MODEL = "nvidia/llama-3.2-nv-embedqa-1b-v2"
+RETRIEVER_RERANK_MODEL = "nvidia/llama-nemotron-rerank-1b-v2"
+RETRIEVER_EMBEDDING_MODEL = "nvidia/nv-embedqa-e5-v5"
 
 # API Keys
 TAVILY_API_KEY = os.environ.get("TAVILY_API_KEY", "")

--- a/code/3-agent-evaluation/evaluation_framework.answers.py
+++ b/code/3-agent-evaluation/evaluation_framework.answers.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # Model Configuration
 JUDGE_MODEL = "nvidia/nemotron-3-super-120b-a12b"
-EMBEDDING_MODEL = "nvidia/llama-3.2-nv-embedqa-1b-v2"
+EMBEDDING_MODEL = "nvidia/nv-embedqa-e5-v5"
 
 
 class EvaluationResult(BaseModel):

--- a/code/3-agent-evaluation/evaluation_framework.py
+++ b/code/3-agent-evaluation/evaluation_framework.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # Model Configuration
 JUDGE_MODEL = "nvidia/nemotron-3-super-120b-a12b"
-EMBEDDING_MODEL = "nvidia/llama-3.2-nv-embedqa-1b-v2"
+EMBEDDING_MODEL = "nvidia/nv-embedqa-e5-v5"
 
 
 class EvaluationResult(BaseModel):

--- a/demo/backend/rag.py
+++ b/demo/backend/rag.py
@@ -19,8 +19,8 @@ from langchain_core.tools.retriever import create_retriever_tool
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data", "it-knowledge-base")
 CHUNK_SIZE = 800
 CHUNK_OVERLAP = 120
-EMBEDDING_MODEL = "nvidia/llama-3.2-nv-embedqa-1b-v2"
-RERANK_MODEL = "nvidia/llama-3.2-nv-rerankqa-1b-v2"
+EMBEDDING_MODEL = "nvidia/nv-embedqa-e5-v5"
+RERANK_MODEL = "nvidia/llama-nemotron-rerank-1b-v2"
 
 # ── Lazy singleton ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #35 

Both nvidia/llama-3.2-nv-embedqa-1b-v2 and nvidia/llama-3.2-nv-rerankqa-1b-v2 reached end-of-life on 2026-05-18 and return [410] Gone errors.

- Embedding: llama-3.2-nv-embedqa-1b-v2 → nv-embedqa-e5-v5
- Reranker:  llama-3.2-nv-rerankqa-1b-v2 → llama-nemotron-rerank-1b-v2

Updated all references across code, answer keys, demo backend, and docs.

