### PR TITLE
fix: add LangSmith regional endpoint support and source step

### DIFF
--- a/.devx/1-build-an-agent/secrets.md
+++ b/.devx/1-build-an-agent/secrets.md
@@ -58,6 +58,24 @@ Manage your API Keys from the [LangSmith Settings](https://smith.langchain.com/s
 
 </details>
 
+<details>
+<summary>⚠️ Outside the US?</summary>
+
+LangSmith has regional endpoints. Edit `variables.env` and set both `LANGSMITH_ENDPOINT` and `LANGCHAIN_ENDPOINT` to the endpoint for your region:
+
+- **GCP US (default):** `https://api.smith.langchain.com`
+- **GCP EU:**           `https://eu.api.smith.langchain.com`
+- **GCP APAC:**         `https://apac.api.smith.langchain.com`
+- **AWS US:**           `https://aws.api.smith.langchain.com`
+
+After editing, reload the file in your terminal before starting the agent:
+
+```bash
+source /project/variables.env
+```
+
+</details>
+
 ---
 
 Once your secrets are configured, continue to [Why Agents?](why_agents.md) to learn about the problem agents solve and when to use them.

--- a/.devx/2-agentic-rag/running.md
+++ b/.devx/2-agentic-rag/running.md
@@ -18,6 +18,12 @@ While other frameworks may provide different ways to deploy agents, the core ide
 
 To get started, start a new <button onclick="openNewTerminal();"><i class="fas fa-terminal"></i> terminal</button> here in Jupyter.
 
+Load your environment variables (re-run this any time you edit `variables.env`):
+
+```bash
+source /project/variables.env
+```
+
 Change to the `code/2-agentic-rag` directory:
 
 ```bash

--- a/.devx/2-agentic-rag/secrets.md
+++ b/.devx/2-agentic-rag/secrets.md
@@ -58,6 +58,24 @@ Manage your API Keys from the [LangSmith Settings](https://smith.langchain.com/s
 
 </details>
 
+<details>
+<summary>⚠️ Outside the US?</summary>
+
+LangSmith has regional endpoints. Edit `variables.env` and set both `LANGSMITH_ENDPOINT` and `LANGCHAIN_ENDPOINT` to the endpoint for your region:
+
+- **GCP US (default):** `https://api.smith.langchain.com`
+- **GCP EU:**           `https://eu.api.smith.langchain.com`
+- **GCP APAC:**         `https://apac.api.smith.langchain.com`
+- **AWS US:**           `https://aws.api.smith.langchain.com`
+
+After editing, reload the file in your terminal before starting the agent:
+
+```bash
+source /project/variables.env
+```
+
+</details>
+
 ---
 
 Once you're ready, continue to the [Introduction to RAG](intro.md) section to get started with agentic RAG.

--- a/.devx/3-agent-evaluation/secrets.md
+++ b/.devx/3-agent-evaluation/secrets.md
@@ -60,6 +60,22 @@ Manage your API Keys from the [LangSmith Settings](https://smith.langchain.com/s
 
 </details>
 
+<details>
+<summary>⚠️ Outside the US?</summary>
+
+LangSmith has regional endpoints. Edit `variables.env` and set both `LANGSMITH_ENDPOINT` and `LANGCHAIN_ENDPOINT` to the endpoint for your region:
+
+- **GCP US (default):** `https://api.smith.langchain.com`
+- **GCP EU:**           `https://eu.api.smith.langchain.com`
+- **GCP APAC:**         `https://apac.api.smith.langchain.com`
+- **AWS US:**           `https://aws.api.smith.langchain.com`
+
+After editing, reload the file in your terminal before starting the agent:
+
+```bash
+source /project/variables.env
+```
+
 </details>
 
 ## Ready to Evaluate!

--- a/.devx/4-agent-customization/secrets.md
+++ b/.devx/4-agent-customization/secrets.md
@@ -65,6 +65,22 @@ Manage your API Keys from the [LangSmith Settings](https://smith.langchain.com/s
 
 </details>
 
+<details>
+<summary>⚠️ Outside the US?</summary>
+
+LangSmith has regional endpoints. Edit `variables.env` and set both `LANGSMITH_ENDPOINT` and `LANGCHAIN_ENDPOINT` to the endpoint for your region:
+
+- **GCP US (default):** `https://api.smith.langchain.com`
+- **GCP EU:**           `https://eu.api.smith.langchain.com`
+- **GCP APAC:**         `https://apac.api.smith.langchain.com`
+- **AWS US:**           `https://aws.api.smith.langchain.com`
+
+After editing, reload the file in your terminal before starting the agent:
+
+```bash
+source /project/variables.env
+```
+
 </details>
 
 ## Ready to Customize!

--- a/.devx/5-deep-agents/secrets.md
+++ b/.devx/5-deep-agents/secrets.md
@@ -64,6 +64,22 @@ Manage your API Keys from the [LangSmith Settings](https://smith.langchain.com/s
 
 </details>
 
+<details>
+<summary>⚠️ Outside the US?</summary>
+
+LangSmith has regional endpoints. Edit `variables.env` and set both `LANGSMITH_ENDPOINT` and `LANGCHAIN_ENDPOINT` to the endpoint for your region:
+
+- **GCP US (default):** `https://api.smith.langchain.com`
+- **GCP EU:**           `https://eu.api.smith.langchain.com`
+- **GCP APAC:**         `https://apac.api.smith.langchain.com`
+- **AWS US:**           `https://aws.api.smith.langchain.com`
+
+After editing, reload the file in your terminal before starting the agent:
+
+```bash
+source /project/variables.env
+```
+
 </details>
 
 ## Ready to Go!

--- a/variables.env
+++ b/variables.env
@@ -1,4 +1,11 @@
 SHELL=/bin/bash
 LANGSMITH_TRACING=true
+# Set the endpoint for your region:
+#   GCP US (default): https://api.smith.langchain.com
+#   GCP EU:           https://eu.api.smith.langchain.com
+#   GCP APAC:         https://apac.api.smith.langchain.com
+#   AWS US:           https://aws.api.smith.langchain.com
 LANGSMITH_ENDPOINT=https://api.smith.langchain.com
+# LANGCHAIN_ENDPOINT mirrors LANGSMITH_ENDPOINT for older langsmith client versions
+LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
 LANGSMITH_PROJECT=nv-devx


### PR DESCRIPTION
Fixes #37 

Users outside the US were silently sending traces to the wrong endpoint, causing tracing to fail with no clear error.

- variables.env: add regional endpoint comment block (GCP US/EU/APAC and AWS US) and add LANGCHAIN_ENDPOINT mirroring LANGSMITH_ENDPOINT for older langsmith client versions
- running.md: add explicit `source /project/variables.env` step before `langgraph dev` so env changes are picked up in the current session
- All 5 module secrets.md files: add "Outside the US?" collapsible callout with correct regional endpoints and the source step